### PR TITLE
fix URLs and ls -l → ls -a

### DIFF
--- a/homebrew.md
+++ b/homebrew.md
@@ -59,7 +59,7 @@ brew install gnuplot
 
 ## SSH の方法
 
-ceenvの場合と同様の操作でSSH接続が出来る。ceenvで用いる"LXTerminal"をmacOSのターミナルであると思って操作をすればよい。詳しくは[ECCSへのリモートアクセス](ssh_to_eccs)を参照されたい。
+ceenvの場合と同様の操作でSSH接続が出来る。ceenvで用いる"LXTerminal"をmacOSのターミナルであると思って操作をすればよい。詳しくは[ECCSへのリモートアクセス](https://utphys-comp.github.io/ssh-to-eccs)を参照されたい。
 
 ## テキストエディター
 

--- a/matlab.md
+++ b/matlab.md
@@ -26,14 +26,14 @@
 
 * MATLAB (デスクトップ版、Online、Mobile)、MATLAB Driveの利用に必要
 * UTokyo MATLAB Campus-Wide Licenseのページへ進む
-[https://utelecon.adm.u-tokyo.ac.jp/](https://utelecon.adm.u-tokyo.ac.jp/)
+[https://utelecon.adm.u-tokyo.ac.jp/matlab/](https://utelecon.adm.u-tokyo.ac.jp/matlab/)
 * 「東京大学の包括ライセンスページ」をクリック
 * 「サインインして使い始める」をクリック
 * UTokyo Accountを要求されるので、入力
 * 「Create a MathWorks Account」をクリック
 * アカウント作成画面が出るので必要事項を入力。メールアドレスにはECCSクラウドメールのアドレス(xxxxx@g.ecc.u-tokyo.ac.jp)を入力
 * メールアドレス確認のためのメールが届くので、「メールの確認」をクリック
-* 参考: https://www.sodan.ecc.u-tokyo.ac.jp/faq/utokyo-matlab-cwl/
+* 参考: [https://www.sodan.ecc.u-tokyo.ac.jp/faq/utokyo-matlab-cwl/](https://www.sodan.ecc.u-tokyo.ac.jp/faq/utokyo-matlab-cwl/)
 
 ## MATLAB (デスクトップ版)のインストール
 

--- a/ssh-to-eccs.md
+++ b/ssh-to-eccs.md
@@ -16,7 +16,7 @@
     - ```Enter passphrase (empty for no passphrase):``` と訊かれるのでパスフレーズを入力し return キー(あるいは enter キー)を押す
     - ```Enter same passphrase again:``` と訊かれるので、上と同じパスフレーズを入力し return キー(あるいは enter キー)を押す
     - ここで入力する「パスフレーズ」は、UTokyo Accountなどの「パスワード」とは別のものである。「パスフレーズ」は自分で決める文字列であり、他のサービスに用いる「パスワード」とは異なるものにすべきである。また、設定した「パスフレーズ」は忘れずに覚えておくこと
-    - 秘密鍵が ```$HOME/.ssh/id_rsa``` に、公開鍵が ```$HOME/.ssh/id_rsa.pub``` に作成される(コマンドラインから ```ls -l $HOME``` を実行してみよ)
+    - 秘密鍵が ```$HOME/.ssh/id_rsa``` に、公開鍵が ```$HOME/.ssh/id_rsa.pub``` に作成される(コマンドラインから ```ls -a $HOME``` を実行して、```.ssh```というディレクトリが作成されていることを確認してみよ)
 
 1. ECCSにSSH公開鍵を登録 (初回のみ)
     - 仮想OS (ceenv)上で LXTerminal を開き、```cat  $HOME/.ssh/id_rsa.pub | xsel -b -i``` を実行する


### PR DESCRIPTION
- homebrew.md で62行目URLを修正
  - 404となっているので埋め込みURLを修正
- matlab.mdで29行目、36行目のURL修正
  - 29行目：utelecon全体ではなく、utelecon内のMATLABのページへ
  - 36行目：リンクになっておらず文字列になっているので修正
- ssh-to-eccs.md で19行目、`ls -l`を`ls -a`に
  - これは`ls -a` で `.ssh` フォルダが作成されていることを確認する、ということだと判断し修正